### PR TITLE
Fix image cachebust job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,10 @@ jobs:
       - run:
           name: "Bust GitHub Cache"
           command: |
+            print "Busting GitHub Image Cache"
+            which curl
+            which grep
+            which xargs
             curl -s https://github.com/erickrawczyk/resume/blob/master/README.md > readme.html
             grep -Eo '<img src=\\"[^"]+\\"' readme.html | grep camo | grep -Eo 'https[^"\\]+' | xargs -I {} curl -w "\n" -s -X PURGE {}
             exit 0
@@ -87,6 +91,6 @@ workflows:
           requires:
             - release-pdf
             - release-jpg
-          filters:
-            branches:
-              only: main
+          # filters:
+          # branches:
+          # only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,13 @@ jobs:
       - run:
           name: "Bust GitHub Cache"
           command: |
-            which curl
-            which grep
-            which xargs
+            echo "Downloading README.md from GitHub..."
             curl -s https://github.com/erickrawczyk/resume/blob/master/README.md > readme.html
-            ls -al
-            grep -Eo '<img src=\\"[^"]+\\"' readme.html | grep camo | grep -Eo 'https[^"\\]+' | xargs -I {} curl -w "\n" -s -X PURGE {}
+            echo "Extracting image URLs from README.md..."
+            grep -Eo '<img src=\\"[^"]+\\"' readme.html | grep camo | grep -Eo 'https[^"\\]+' > urls.txt
+            cat urls.txt
+            echo "Purging image cache..."
+            xargs -I {} curl -w "\n" -s -X PURGE {} < urls.txt
             exit 0
 workflows:
   export-and-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,7 @@ jobs:
             which grep
             which xargs
             curl -s https://github.com/erickrawczyk/resume/blob/master/README.md > readme.html
+            ls -al
             grep -Eo '<img src=\\"[^"]+\\"' readme.html | grep camo | grep -Eo 'https[^"\\]+' | xargs -I {} curl -w "\n" -s -X PURGE {}
             exit 0
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,9 @@ jobs:
           command: |
             echo "Downloading README.md from GitHub..."
             curl -s https://github.com/erickrawczyk/resume/blob/master/README.md > readme.html
+            cat readme.html
             echo "Extracting image URLs from README.md..."
-            grep -Eo '<img src=\\"[^"]+\\"' readme.html | grep camo | grep -Eo 'https[^"\\]+' > urls.txt
+            grep -o '<img src="https://camo.githubusercontent.com[^"]*' readme.html | sed -E 's/<img src="([^"]+).*/\1/' > urls.txt
             cat urls.txt
             echo "Purging image cache..."
             xargs -I {} curl -w "\n" -s -X PURGE {} < urls.txt

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ jobs:
       - run:
           name: "Bust GitHub Cache"
           command: |
-            print "Busting GitHub Image Cache"
             which curl
             which grep
             which xargs
@@ -87,10 +86,10 @@ workflows:
           filters:
             branches:
               only: main
-      - bust-github-image-cache:
-          requires:
-            - release-pdf
-            - release-jpg
-          # filters:
-          # branches:
-          # only: main
+      - bust-github-image-cache
+        # requires:
+        #   - release-pdf
+        #   - release-jpg
+        # filters:
+        # branches:
+        # only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,13 +66,11 @@ jobs:
           command: |
             echo "Downloading README.md from GitHub..."
             curl -s https://github.com/erickrawczyk/resume/blob/master/README.md > readme.html
-            cat readme.html
             echo "Extracting image URLs from README.md..."
             grep -o '<img src="https://camo.githubusercontent.com[^"]*' readme.html | sed -E 's/<img src="([^"]+).*/\1/' > urls.txt
             cat urls.txt
             echo "Purging image cache..."
             xargs -I {} curl -w "\n" -s -X PURGE {} < urls.txt
-            exit 0
 workflows:
   export-and-release:
     jobs:
@@ -89,10 +87,10 @@ workflows:
           filters:
             branches:
               only: main
-      - bust-github-image-cache
-        # requires:
-        #   - release-pdf
-        #   - release-jpg
-        # filters:
-        # branches:
-        # only: main
+      - bust-github-image-cache:
+          requires:
+            - release-pdf
+            - release-jpg
+          filters:
+            branches:
+              only: main


### PR DESCRIPTION
This PR fixes the job that busts the github cache of the generated image, so that changes to main are propagated to the readme image on the repo page quickly.